### PR TITLE
only firefox takes applications

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
     "description": "A debugger for viewing SAML messages",
     "manifest_version": 2,
     "version": "0.4.0",
+    // only firefox takes 'applications' - mandatory in its manifest. other browsers choke on this :(
     "applications": {
         "gecko": {
           "id": "{d3e01ff2-9a3a-4007-8f6e-7acd9a5de263}"


### PR DESCRIPTION
we'll need a separate manifest built for Chrome/Opera etc :(

many thanks for your work on the Web Extensions. with the change to the manifest and
using chrome.* instead of browser.*, where needed, the SAML tracer now loads without error and works on other browsers too!